### PR TITLE
LOAD_PATHS moved to config.LOAD_PATHS

### DIFF
--- a/flaskext/scss.py
+++ b/flaskext/scss.py
@@ -39,12 +39,12 @@ class Scss(object):
         self.assets = {}
         self.partials = {}
 
-        if hasattr(pyScss.LOAD_PATHS, 'split'):
-            pyScss.LOAD_PATHS = pyScss.LOAD_PATHS.split(',')
+        if hasattr(pyScss.config.LOAD_PATHS, 'split'):
+            pyScss.config.LOAD_PATHS = pyScss.config.LOAD_PATHS.split(',')
         load_path_list = [self.asset_dir] \
                        + (load_paths or app.config.get('SCSS_LOAD_PATHS', []))
         for path in load_path_list:
-            pyScss.LOAD_PATHS.append(path)
+            pyScss.config.LOAD_PATHS.append(path)
 
         pyScss.log = app.logger
         self.compiler = pyScss.Scss().compile


### PR DESCRIPTION
scss.LOAD_PATHS is no longer valid; pyScss now uses scss.config.LOAD_PATHS, starting with version 1.1.5.

The pertinent pyScss commit:  Kronuz/pyScss@1c4335b1e38908eb77563028edd501c435d18642
